### PR TITLE
質問を送信したら質問チェックが一旦自動で外れるようにしたい

### DIFF
--- a/bolide_front/Pages/Index.razor
+++ b/bolide_front/Pages/Index.razor
@@ -99,6 +99,7 @@ else
         if(comment=="")return;
         connection.PostComment(comment, isQuestion);
         comment = "";
+        isQuestion = false;
         StateHasChanged();
     }
 }


### PR DESCRIPTION
現行版では質問送信した後にチェックが入れっぱなしになります。
手動でチェック外さないと次のコメントも意図せず質問になるのが不便だなと思い、差分を作ってみました。

ちょっと開発環境のつくり方まで調べれてなくて手元確認していないのですが、ニュアンスはつかめると思います(